### PR TITLE
Return null data object on missing related resource

### DIFF
--- a/jsonapi/data_structs.go
+++ b/jsonapi/data_structs.go
@@ -130,6 +130,16 @@ type Relationship struct {
 	Meta  map[string]interface{}     `json:"meta,omitempty"`
 }
 
+func (r Relationship) MarshalJSON() ([]byte, error) {
+	type Alias Relationship
+
+	if r.Data != nil && r.Data.DataObject != nil && r.Data.DataObject.ID == "" {
+		r.Data.DataObject = nil
+	}
+
+	return json.Marshal(&struct{ Alias }{Alias: (Alias)(r)})
+}
+
 // A RelationshipDataContainer is used to marshal and unmarshal single relationship
 // objects and arrays of relationship objects.
 type RelationshipDataContainer struct {

--- a/jsonapi/data_structs_test.go
+++ b/jsonapi/data_structs_test.go
@@ -161,6 +161,41 @@ var _ = Describe("JSONAPI Struct tests", func() {
 		Expect(target.Data.DataArray).To(Equal([]Data{expectedData}))
 	})
 
+	Context("Marshal and Unmarshal data structs", func() {
+		It("nulls out missing relationship objects", func() {
+			data := Data{
+				Type:       "test",
+				ID:         "1",
+				Attributes: json.RawMessage([]byte(`{"foo": "bar"}`)),
+				Relationships: map[string]Relationship{
+					"comments": {
+						Data: &RelationshipDataContainer{
+							DataObject: &RelationshipData{
+								Type: "",
+								ID:   "",
+							},
+						},
+					},
+				},
+			}
+
+			expectedJSON := `{
+				"type": "test",
+				"id": "1",
+				"attributes": {"foo": "bar"},
+				"relationships": {
+					"comments": {
+						"data": null
+					}
+				}
+			}`
+
+			ret, err := json.Marshal(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(MatchJSON(expectedJSON))
+		})
+	})
+
 	Context("Marshal and Unmarshal link structs", func() {
 		It("marshals to a string with no metadata", func() {
 			link := Link{Href: "test link"}

--- a/jsonapi/unmarshal_test.go
+++ b/jsonapi/unmarshal_test.go
@@ -120,6 +120,19 @@ var _ = Describe("Unmarshal", func() {
 			Expect(err.Error()).To(Equal("error"))
 		})
 
+		It("errors if the type is not present", func() {
+			post := ErrorIDPost{}
+			err := Unmarshal([]byte(`{
+				"data": {
+					"attributes": {
+						"title": "test"
+					}
+				}
+			}`), &post)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("invalid record, no type was specified"))
+		})
+
 		It("errors on invalid param nil", func() {
 			err := Unmarshal(singlePostJSON, nil)
 			Expect(err).Should(HaveOccurred())
@@ -238,6 +251,20 @@ var _ = Describe("Unmarshal", func() {
 			err := Unmarshal(json, &post)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Cannot unmarshal array to struct target jsonapi.SimplePost"))
+		})
+
+		It("errors if the type is not present", func() {
+			json := []byte(`{
+				"data": [{
+					"attributes": {
+						"title": "something"
+					}
+				}]
+			}`)
+			var posts []SimplePost
+			err := Unmarshal(json, &posts)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("invalid record, no type was specified"))
 		})
 
 		Context("slice fields", func() {
@@ -570,6 +597,22 @@ var _ = Describe("Unmarshal", func() {
 			err := Unmarshal(postJSON, &posts)
 			Expect(err).To(BeNil())
 			Expect(posts).To(Equal([]Post{{ID: 1, Title: "New Title"}}))
+		})
+
+		It("errors if the type is not present", func() {
+			post := Post{ID: 1, Title: "Old Title"}
+			postJSON := []byte(`{
+				"data": [{
+					"id":   "1",
+					"attributes": {
+						"title": "New Title"
+					}
+				}]
+			}`)
+			posts := []Post{post}
+			err := Unmarshal(postJSON, &posts)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("invalid record, no type was specified"))
 		})
 	})
 


### PR DESCRIPTION
As per the spec (https://jsonapi.org/format/#fetching-resources) if the related resource is empty then the data resource should be null, rather than the current behaviour of omitting the empty field